### PR TITLE
add socks proxy support

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "got": "^11.8.2",
     "https-proxy-agent": "^5.0.0",
     "p-map": "^4.0.0",
+    "socks-proxy-agent": "^7.0.0",
     "ws": "^8.4.0"
   },
   "devDependencies": {

--- a/src/handy.ts
+++ b/src/handy.ts
@@ -7,6 +7,7 @@ import path from 'path'
 import { debug } from './debug'
 import { Mapper } from './mappers'
 import { Disconnect, Exchange, Filter, FilterForExchange } from './types'
+import { SocksProxyAgent } from 'socks-proxy-agent'
 
 export function parseAsUTCDate(val: string) {
   // not sure about this one, but it should force parsing date as UTC date not as local timezone
@@ -234,7 +235,11 @@ const httpsAgent = new https.Agent({
 })
 
 export const httpsProxyAgent: https.Agent | undefined =
-  process.env.HTTP_PROXY !== undefined ? createHttpsProxyAgent(process.env.HTTP_PROXY) : undefined
+  process.env.HTTP_PROXY !== undefined
+    ? createHttpsProxyAgent(process.env.HTTP_PROXY)
+    : process.env.SOCKS_PROXY !== undefined
+    ? new SocksProxyAgent(process.env.SOCKS_PROXY)
+    : undefined
 
 export async function download({
   apiKey,


### PR DESCRIPTION
This adds the ability to use Socks proxy by setting `process.env.SOCKS_PROXY` to something like `socks://127.0.0.1:9050`

`socks-proxy-agent` is by the best Socks proxy agent available to my knowledge (I've tried most of the others). It has been reliable.

I have tested the socks proxy to work in these scenarios using `yarn link`
- No socks proxy (works)
- Offline/invalid socks proxy (can't fetch data as expected)
- Online socks proxy (works)
- Offline/invalid http proxy (can't fetch data as expected)
- Online Http proxy (works)
- console.log to make sure the `yarn link` worked