### PR TITLE
[hotfix] Change Phemex WS URL

### DIFF
--- a/src/realtimefeeds/phemex.ts
+++ b/src/realtimefeeds/phemex.ts
@@ -2,7 +2,7 @@ import { Filter } from '../types'
 import { RealTimeFeedBase } from './realtimefeed'
 
 export class PhemexRealTimeFeed extends RealTimeFeedBase {
-  protected readonly wssURL = 'wss://phemex.com/ws'
+  protected readonly wssURL = 'wss://ws.phemex.com/'
   protected readonly throttleSubscribeMS = 100
 
   protected readonly channelsMap = {


### PR DESCRIPTION
Request to https://phemex.com/ws returns 410 Gone error:
```
Improperly api requests.
Public api user endpoints:
    Rest API: https://api.phemex.com
    Websocket (further URI or querystring not allowed): wss://ws.phemex.com
```

This PR changes URL to wss://ws.phemex.com